### PR TITLE
ci: Split GitHub environments into components

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,13 +156,13 @@ jobs:
     name: "Frontend: Deploy Preview"
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    environment:
-      name: preview
-      url: ${{ steps.app-name.outputs.app-url }}
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       FLY_ORG: ${{ vars.FLY_ORG }}
     needs: frontend-build-push
+    environment:
+      name: preview-frontend
+      url: ${{ steps.app-name.outputs.app-url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -221,6 +221,9 @@ jobs:
       - frontend-unit-tests
       - e2e-tests
       - define-env
+    environment:
+      name: ${{ needs.define-env.outputs.environment }}-frontend
+      url: https://${{ needs.define-env.outputs.canonical_hostname_frontend }}/
     steps:
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
@@ -299,6 +302,9 @@ jobs:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       FLY_ORG: ${{ vars.FLY_ORG }}
     needs: cms-build-push
+    environment:
+      name: preview-cms
+      url: ${{ steps.app-name.outputs.app-url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -364,6 +370,9 @@ jobs:
       - cms-check-format
       - e2e-tests
       - define-env
+    environment:
+      name: ${{ needs.define-env.outputs.environment }}-cms
+      url: https://${{ needs.define-env.outputs.domain_cms }}/
     steps:
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
@@ -384,6 +393,17 @@ jobs:
             --env SERVER_URL=https://${{ needs.define-env.outputs.domain_cms }} \
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - name: Wait 30s for app to become ready
+        run: sleep 30
+      - name: Prime frontend cache
+        # We rely here on the frontend deployment being significantly faster
+        # – We can't make cache priming a separate job because we need an environment secret
+        # - We should anyway add some logic to synchronize the deployments (or simply merge them)
+        run: |
+          curl "https://${{ needs.define-env.outputs.domain_cms }}/api/prime-frontend-cache" \
+            -f -s -S \
+            -X POST \
+            -H "Authorization: users API-Key ${{ secrets.CICD_USER_API_KEY }}"
 
   e2e-tests:
     name: End-to-End Tests
@@ -512,19 +532,3 @@ jobs:
     permissions:
       contents: write
   
-  prime-frontend-cache:
-    name: Prime Frontend Cache
-    runs-on: ubuntu-latest
-    needs: [define-env, frontend-deploy, cms-deploy]
-    environment:
-      name: ${{ needs.define-env.outputs.environment }}
-      url: https://${{ needs.define-env.outputs.canonical_hostname_frontend }}/
-    steps:
-      - name: Wait 30s for apps to become ready
-        run: sleep 30
-      - name: Prime frontend cache
-        run: |
-          curl "https://${{ needs.define-env.outputs.domain_cms }}/api/prime-frontend-cache" \
-            -f -s -S \
-            -X POST \
-            -H "Authorization: users API-Key ${{ secrets.CICD_USER_API_KEY }}"


### PR DESCRIPTION
Closes #38

Deployment status is now reported correctly again.

Replaces #282 