### PR TITLE
[codex] Use Fly autosuspend for app machines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: "Build"
-    uses: felixmokross/webplatform/.github/workflows/export.build.yml@main
+    uses: fxmkdev/webplatform/.github/workflows/export.build.yml@main
     permissions:
       contents: write
     secrets: inherit

--- a/.github/workflows/clean-preview.yml
+++ b/.github/workflows/clean-preview.yml
@@ -7,5 +7,5 @@ on:
 jobs:
   clean-preview:
     name: Clean Preview
-    uses: felixmokross/webplatform/.github/workflows/export.clean-preview.yml@main
+    uses: fxmkdev/webplatform/.github/workflows/export.clean-preview.yml@main
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   deploy:
     name: "Deploy"
-    uses: felixmokross/webplatform/.github/workflows/export.deploy.yml@main
+    uses: fxmkdev/webplatform/.github/workflows/export.deploy.yml@main
     with:
       environment: ${{ inputs.environment }}
     secrets: inherit

--- a/apps/cms/fly.template.toml
+++ b/apps/cms/fly.template.toml
@@ -8,7 +8,7 @@ primary_region = '$FLY_PRIMARY_REGION'
 [http_service]
   internal_port = 3001
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = $FLY_MIN_MACHINES_RUNNING
   processes = ['app']

--- a/apps/frontend/fly.template.toml
+++ b/apps/frontend/fly.template.toml
@@ -8,7 +8,7 @@ primary_region = '$FLY_PRIMARY_REGION'
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = $FLY_MIN_MACHINES_RUNNING
   processes = ['app']


### PR DESCRIPTION
## Problem / Context

Fly.io supports `auto_stop_machines = "suspend"`, which can resume machines faster than a full stop/start cycle while still avoiding CPU/RAM charges when machines are not running. The existing frontend and CMS Fly templates used boolean autostop.

While opening this PR, the Build workflow also failed before creating jobs because the reusable workflow references still pointed at the old `felixmokross/webplatform` owner.

## What Changed

- Updated frontend and CMS Fly templates to use `auto_stop_machines = "suspend"`.
- Kept `auto_start_machines = true` and `min_machines_running = $FLY_MIN_MACHINES_RUNNING` unchanged.
- Updated GitHub Actions reusable workflow references from `felixmokross/webplatform` to `fxmkdev/webplatform` for Build, Deploy, and Clean Preview.
- Added an empty rerun commit after `fxmkdev/webplatform` updated its pinned Fly CLI to `0.4.52`, so this PR's checks resolve the new reusable workflow version.

## Validation

- `rg -n "auto_stop_machines" apps`
- `rg -n "felixmokross/webplatform|fxmkdev/webplatform" .github`
- CI now resolves the reusable Build workflow and starts jobs.
- CI passes lint, format, unit tests, typecheck, CMS type population, Storybook publish, image build/push, and e2e tests.

## Risks / Mitigations

- Environments with `FLY_MIN_MACHINES_RUNNING=1` or higher will still keep machines running as configured; this PR intentionally preserves that policy.
- Fly suspend/resume behavior depends on Fly platform support and app compatibility, but the config uses Fly's documented `"suspend"` value.

## Current CI Note

The previous Fly registry `401 Unauthorized` image-push failures are resolved by the shared workflow's Fly CLI update to `0.4.52`.

`Build / Deploy Preview / CMS: Deploy` is currently failing in the release command because Payload cannot resolve the preview MongoDB SRV host: `querySrv ENOTFOUND _mongodb._tcp.cluster0.m5afgak.mongodb.net`. This is a runtime connectivity/DNS issue during CMS migration, not the earlier Fly registry push failure.

## Follow-ups

- Check preview CMS database connectivity/DNS for the `PREVIEW_DATABASE_URI` used by the deploy-preview environment if the CMS deploy failure persists.