### PR TITLE
chore: add renovate dependency automation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "schedule:weekly",
+    ":semanticPrefixChore(deps)",
+    ":rebaseStalePrs"
+  ],
+  "timezone": "Europe/Zurich",
+  "automerge": false,
+  "dependencyDashboard": true,
+  "configMigration": true,
+  "rangeStrategy": "bump",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "enabledManagers": ["npm", "dockerfile", "docker-compose", "github-actions"],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["dependencies", "security"]
+  },
+  "packageRules": [
+    {
+      "groupName": "Payload CMS",
+      "matchPackageNames": ["payload", "@payloadcms/**"]
+    },
+    {
+      "groupName": "React Router",
+      "matchPackageNames": ["react-router", "@react-router/**"]
+    },
+    {
+      "groupName": "Next.js",
+      "matchPackageNames": ["next", "eslint-config-next", "@next/**"]
+    },
+    {
+      "groupName": "React",
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ]
+    },
+    {
+      "groupName": "Storybook",
+      "matchPackageNames": ["storybook", "@storybook/**", "chromatic"]
+    },
+    {
+      "groupName": "Vite and Vitest",
+      "matchPackageNames": [
+        "vite",
+        "vitest",
+        "@vitejs/**",
+        "vite-tsconfig-paths",
+        "vite-plugin-turbosnap"
+      ]
+    },
+    {
+      "groupName": "Tailwind CSS",
+      "matchPackageNames": [
+        "tailwindcss",
+        "@tailwindcss/**",
+        "@tailwindcss/forms",
+        "prettier-plugin-tailwindcss"
+      ]
+    },
+    {
+      "groupName": "Linting",
+      "matchPackageNames": [
+        "eslint",
+        "@eslint/**",
+        "typescript-eslint",
+        "eslint-plugin-react",
+        "globals"
+      ]
+    },
+    {
+      "groupName": "TypeScript",
+      "matchPackageNames": ["typescript", "@types/node"]
+    },
+    {
+      "groupName": "Testing",
+      "matchPackageNames": ["@testing-library/**", "jsdom", "@playwright/test"]
+    },
+    {
+      "groupName": "i18n",
+      "matchPackageNames": [
+        "i18next",
+        "i18next-*",
+        "react-i18next",
+        "remix-i18next"
+      ]
+    },
+    {
+      "groupName": "fxmk packages",
+      "matchPackageNames": ["@fxmk/**"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "labels": ["dependencies", "major"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Renovate repo configuration for the GitHub App flow
- group related dependency ecosystems so future updates are reviewable
- keep routine updates weekly, disable automerge, and keep security updates immediate

## Notes
- This PR only adds `.github/renovate.json`; it does not update dependencies or lockfiles.
- After merge, the Renovate GitHub App still needs to be enabled/installed for `fxmkdev/lapuertahostels`.
- Major updates require Dependency Dashboard approval before Renovate opens PRs.

## Validation
- `node -e 'JSON.parse(require("fs").readFileSync(".github/renovate.json", "utf8"))'`
- `npm_config_cache=/private/tmp/codex-npm-cache npx --yes --package renovate renovate-config-validator .github/renovate.json`
