### PR TITLE
docs: align Node runtime guidance with Node 24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,9 @@ It includes:
 - Use `pnpm` as package manager.
 - Keep changes focused and minimal; avoid unrelated refactors.
 - Keep docs in sync when introducing new behavior, patterns, or conventions.
-- The runtime target is Node 22. Keep `@types/node` aligned with the current
-  runtime major and do not upgrade to Node 23+ typings until a runtime migration
-  is planned.
+- The runtime target is Node 24. Keep `@types/node` aligned with the current
+  runtime major and do not upgrade beyond Node 24 typings until the next runtime
+  migration is planned.
 - Pull request titles must follow Conventional Commits because squash merge
   commit messages are expected to come from the PR title.
   - Format: `<type>(optional-scope): <description>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,8 @@ need to be strictly Conventional Commit formatted.
 
 ## Runtime and Typings Policy
 
-- Keep `@types/node` on the Node 22 line until a runtime migration is scheduled.
+- Keep `@types/node` on the Node 24 line until the next runtime migration is
+  scheduled.
 
 ## Review Comment Workflow
 


### PR DESCRIPTION
## Summary
- Update contributor and agent runtime guidance to match the Node 24 upgrade already present on `origin/main`.
- Keep the PR scoped to docs only; package manifests, lockfile, Dockerfiles, dependencies, and version-manager files are unchanged.

## Testing
- `rg -n "Node 22|Node 23|runtime target|@types/node" AGENTS.md CONTRIBUTING.md package.json apps tests libs`
- `git diff --check -- AGENTS.md CONTRIBUTING.md`
