### PR TITLE
chore(deps): upgrade chromatic to 17

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -57,7 +57,7 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
-    "chromatic": "^16.10.1",
+    "chromatic": "^17.0.0",
     "eslint": "^10.4.0",
     "globals": "^16.3.0",
     "jsdom": "^29.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,8 +225,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.77.4)(tsx@4.21.0))
       chromatic:
-        specifier: ^16.10.1
-        version: 16.10.1
+        specifier: ^17.0.0
+        version: 17.0.0
       eslint:
         specifier: ^10.4.0
         version: 10.4.0(jiti@2.7.0)
@@ -3805,8 +3805,9 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  chromatic@16.10.1:
-    resolution: {integrity: sha512-u3RusLCCJxN8IZV3qLh6RTpo6Mu5A77bpOTAGJL5A+v2to9fsVKcK3j0GvGjPQeJJPNSI8rAI5c4U9ukbGiZJQ==}
+  chromatic@17.0.0:
+    resolution: {integrity: sha512-gYbIBg6IoqH9Ut+bVE5uTZmGzmv/aoHcFzAXaym08JZ7FkB3OSjxrq1xO/dhMPfMqpnwzycHZytYIp3N+IZr5w==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       '@chromatic-com/cypress': ^0.*.* || ^1.0.0
@@ -10817,7 +10818,7 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  chromatic@16.10.1:
+  chromatic@17.0.0:
     dependencies:
       semver: 7.8.0
 


### PR DESCRIPTION
## Summary
- upgrades the frontend `chromatic` package from v16 to v17
- refreshes the lockfile for the new CLI version
- keeps Storybook packages and configuration unchanged

## Validation
- `pnpm --filter @lapuertahostels/frontend build-storybook`
