### PR TITLE
feat(cms): make room CTAs optional

### DIFF
--- a/apps/cms/src/blocks/room-list/config.ts
+++ b/apps/cms/src/blocks/room-list/config.ts
@@ -69,7 +69,7 @@ export const RoomListBlock: Block = {
             }),
           ],
         },
-        callToActionField(),
+        callToActionField({ optional: true }),
       ],
       admin: {
         components: {

--- a/apps/cms/src/migrations/20260529_000000_optional_room_cta.ts
+++ b/apps/cms/src/migrations/20260529_000000_optional_room_cta.ts
@@ -1,0 +1,128 @@
+import { MigrateDownArgs, MigrateUpArgs } from "@payloadcms/db-mongodb";
+
+type DataRecord = Record<string, unknown>;
+
+export async function up({ payload }: MigrateUpArgs): Promise<void> {
+  const pages = await payload.db.connection
+    .collection("pages")
+    .find({ content: { $exists: true } })
+    .toArray();
+
+  for (const page of pages) {
+    const result = addShowToRoomListCtas(page.content);
+
+    if (!result.changed) {
+      continue;
+    }
+
+    await payload.db.connection.collection("pages").updateOne(
+      { _id: page._id },
+      {
+        $set: {
+          content: result.content,
+        },
+      },
+    );
+  }
+}
+
+export async function down(_: MigrateDownArgs): Promise<void> {
+  // Migration code
+}
+
+function addShowToRoomListCtas(content: unknown): {
+  changed: boolean;
+  content: unknown;
+} {
+  if (Array.isArray(content)) {
+    const result = addShowToContentBlocks(content);
+    return {
+      changed: result.changed,
+      content: result.changed ? result.blocks : content,
+    };
+  }
+
+  if (!isRecord(content)) {
+    return { changed: false, content };
+  }
+
+  let changed = false;
+  const nextContent: DataRecord = { ...content };
+
+  for (const [locale, blocks] of Object.entries(content)) {
+    if (!Array.isArray(blocks)) {
+      continue;
+    }
+
+    const result = addShowToContentBlocks(blocks);
+    if (result.changed) {
+      nextContent[locale] = result.blocks;
+      changed = true;
+    }
+  }
+
+  return {
+    changed,
+    content: changed ? nextContent : content,
+  };
+}
+
+function addShowToContentBlocks(blocks: unknown[]): {
+  blocks: unknown[];
+  changed: boolean;
+} {
+  let changed = false;
+
+  const nextBlocks = blocks.map((block) => {
+    if (
+      !isRecord(block) ||
+      block.blockType !== "RoomList" ||
+      !Array.isArray(block.rooms)
+    ) {
+      return block;
+    }
+
+    let roomChanged = false;
+    const rooms = block.rooms.map((room) => {
+      if (!isRecord(room) || !isRecord(room.cta) || "show" in room.cta) {
+        return room;
+      }
+
+      if (!hasCallToActionData(room.cta)) {
+        return room;
+      }
+
+      roomChanged = true;
+      return {
+        ...room,
+        cta: {
+          ...room.cta,
+          show: true,
+        },
+      };
+    });
+
+    if (!roomChanged) {
+      return block;
+    }
+
+    changed = true;
+    return {
+      ...block,
+      rooms,
+    };
+  });
+
+  return {
+    blocks: changed ? nextBlocks : blocks,
+    changed,
+  };
+}
+
+function hasCallToActionData(cta: DataRecord): boolean {
+  return Boolean(cta.label || cta.link || cta.variant);
+}
+
+function isRecord(value: unknown): value is DataRecord {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/apps/cms/src/migrations/index.ts
+++ b/apps/cms/src/migrations/index.ts
@@ -4,6 +4,7 @@ import * as migration_20250502_175318_rename_maintenance_to_settings from "./202
 import * as migration_20250719_221257_migration from "./20250719_221257_migration";
 import * as migration_20250724_194253_languages from "./20250724_194253_languages";
 import * as migration_20250817_133906_migration from "./20250817_133906_migration";
+import * as migration_20260529_000000_optional_room_cta from "./20260529_000000_optional_room_cta";
 
 export const migrations = [
   {
@@ -35,5 +36,10 @@ export const migrations = [
     up: migration_20250817_133906_migration.up,
     down: migration_20250817_133906_migration.down,
     name: "20250817_133906_migration",
+  },
+  {
+    up: migration_20260529_000000_optional_room_cta.up,
+    down: migration_20260529_000000_optional_room_cta.down,
+    name: "20260529_000000_optional_room_cta",
   },
 ];

--- a/apps/frontend/app/blocks/room-list-block/room-card.stories.tsx
+++ b/apps/frontend/app/blocks/room-list-block/room-card.stories.tsx
@@ -58,3 +58,13 @@ export const Default: Story = {
     cta: requiredCallToAction("Reserve Now"),
   },
 };
+
+export const WithoutCallToAction: Story = {
+  args: {
+    ...Default.args,
+    cta: {
+      ...requiredCallToAction("Reserve Now"),
+      show: false,
+    },
+  },
+};

--- a/apps/frontend/app/blocks/room-list-block/room-card.tsx
+++ b/apps/frontend/app/blocks/room-list-block/room-card.tsx
@@ -34,7 +34,7 @@ export function RoomCard({ heading, text, images, cta }: RoomCardProps) {
           {text as unknown as RichTextObject | undefined}
         </RichTextParagraph>
       )}
-      {cta && (
+      {cta && cta.show !== false && (
         <Button
           as={PageLink}
           link={cta.link}

--- a/apps/frontend/app/blocks/room-list-block/room-list-block.stories.tsx
+++ b/apps/frontend/app/blocks/room-list-block/room-list-block.stories.tsx
@@ -67,7 +67,10 @@ export const Default: Story = {
             image: media("IMG_6814-Mejorado.jpg"),
           },
         ],
-        cta: requiredCallToAction("Reserve Now"),
+        cta: {
+          ...requiredCallToAction("Reserve Now"),
+          show: false,
+        },
       },
       {
         heading: "Standard Room",

--- a/apps/frontend/app/common/cms-data.builders.ts
+++ b/apps/frontend/app/common/cms-data.builders.ts
@@ -64,6 +64,7 @@ export function requiredCallToAction(
   variant?: CallToAction["variant"],
 ): RequiredCallToAction {
   return {
+    show: true,
     label,
     link: customLink("http://example.com/"),
     variant: variant ?? "secondary",


### PR DESCRIPTION
## Problem / Context
Room List rooms currently require a CTA, so CMS editors cannot remove the booking/action button from an individual room even when a room should be informational only.

## What Changed
- Changed the Room List room CTA field to use the existing optional CTA `show` checkbox pattern.
- Updated the frontend room card to hide CTAs only when `show === false`, preserving legacy room CTA data that does not yet have the new field.
- Added a CMS migration to backfill existing Room List room CTAs with `show: true` when CTA data already exists.
- Updated Storybook data to cover both visible and hidden room CTA states.

## User / Developer Impact
CMS editors can now hide the CTA per room without removing or restructuring the room entry. Existing published room CTAs remain visible after deploy and migration.

## Risks and Mitigations
- Risk: existing CTA data could disappear if missing `show` were treated as false. Mitigated by frontend compatibility logic and the backfill migration.
- Risk: generated Payload types need to include the new CTA shape for frontend usage. Mitigated by running CMS build and refreshing shared payload types locally.

## Validation
- `pnpm --filter @lapuertahostels/cms build`
- `pnpm --filter @lapuertahostels/payload-types pull-payload-types`
- `pnpm --filter @lapuertahostels/frontend typecheck`
- `pnpm --filter @lapuertahostels/frontend lint`
- `pnpm --filter @lapuertahostels/frontend test`
- `pnpm --filter @lapuertahostels/cms lint`
- `pnpm --filter @lapuertahostels/cms check-format`
- `pnpm --filter @lapuertahostels/frontend check-format`

## Follow-ups / Known Limitations
None known.