### PR TITLE
feat(frontend): add standalone accommodation card links

### DIFF
--- a/apps/cms/src/blocks/accommodation-selector/config.ts
+++ b/apps/cms/src/blocks/accommodation-selector/config.ts
@@ -5,6 +5,7 @@ import {
   moreOptionsField,
   elementIdField,
   imageField,
+  linkField,
 } from "@fxmk/cms-plugin";
 
 export const AccommodationSelectorBlock: Block = {
@@ -40,20 +41,37 @@ export const AccommodationSelectorBlock: Block = {
         },
       },
       type: "array",
-      minRows: 2,
-      maxRows: 2,
+      minRows: 1,
       required: true,
       fields: [
-        {
-          name: "brand",
-          label: {
-            en: "Brand",
-            es: "Marca",
-          },
-          type: "relationship",
-          relationTo: "brands",
-          filterOptions: { id: { not_equals: "puerta" } },
+        textField({
+          name: "title",
+          label: { en: "Title", es: "Título" },
           required: true,
+        }),
+        linkField(),
+        {
+          name: "color",
+          label: {
+            en: "Color",
+            es: "Color",
+          },
+          type: "select",
+          required: true,
+          options: [
+            {
+              label: "Puerta",
+              value: "puerta",
+            },
+            {
+              label: "Aqua",
+              value: "aqua",
+            },
+            {
+              label: "Azul",
+              value: "azul",
+            },
+          ],
         },
         imageField(),
         richTextField({
@@ -67,8 +85,8 @@ export const AccommodationSelectorBlock: Block = {
       admin: {
         initCollapsed: true,
         description: {
-          en: "Each card represents an accommodation brand. You can change their order and update their image and description here.",
-          es: "Cada tarjeta representa una marca de alojamiento. Puedes cambiar su orden y actualizar su imagen y descripción aquí.",
+          en: "Each card represents a linked accommodation page. You can change their order, target, color, image, and description here.",
+          es: "Cada tarjeta representa una página de alojamiento enlazada. Puedes cambiar su orden, destino, color, imagen y descripción aquí.",
         },
       },
     },

--- a/apps/cms/src/migrations/20260529_224952_accommodation_selector_card_links.ts
+++ b/apps/cms/src/migrations/20260529_224952_accommodation_selector_card_links.ts
@@ -1,0 +1,254 @@
+import { MigrateDownArgs, MigrateUpArgs } from "@payloadcms/db-mongodb";
+
+type Document = Record<string, unknown>;
+type BrandDocument = Document & {
+  homeLink?: unknown;
+  id?: unknown;
+  name?: unknown;
+};
+
+const colorOptions = new Set(["puerta", "aqua", "azul"]);
+
+export async function up({ payload }: MigrateUpArgs): Promise<void> {
+  const brands = await loadBrands(payload);
+
+  await migrateCollection(payload, "pages", "content", brands);
+
+  const collectionNames = await getCollectionNames(payload);
+  const pageVersionCollectionNames = collectionNames.filter((name) =>
+    ["_pages_versions", "pages_versions"].includes(name),
+  );
+
+  for (const collectionName of pageVersionCollectionNames) {
+    await migrateCollection(payload, collectionName, "version.content", brands);
+  }
+}
+
+export async function down(_: MigrateDownArgs): Promise<void> {
+  // Migration code
+}
+
+async function loadBrands(
+  payload: MigrateUpArgs["payload"],
+): Promise<Map<string, BrandDocument>> {
+  const brands = (await payload.db.connection
+    .collection("brands")
+    .find({})
+    .toArray()) as BrandDocument[];
+
+  return new Map(
+    brands.flatMap((brand) =>
+      [brand.id, brand._id]
+        .filter((id): id is string | number | boolean | object => id != null)
+        .map((id) => [String(id), brand]),
+    ),
+  );
+}
+
+async function migrateCollection(
+  payload: MigrateUpArgs["payload"],
+  collectionName: string,
+  contentPath: string,
+  brands: Map<string, BrandDocument>,
+) {
+  const collection = payload.db.connection.collection(collectionName);
+  const documents = (await collection.find({}).toArray()) as Document[];
+
+  for (const document of documents) {
+    const content = getPath(document, contentPath);
+    const { changed, value } = migrateContent(
+      content,
+      brands,
+      `${collectionName}/${String(document._id)}`,
+    );
+
+    if (changed) {
+      const filter = {
+        _id: document._id,
+      } as Parameters<typeof collection.updateOne>[0];
+
+      await collection.updateOne(filter, {
+        $set: {
+          [contentPath]: value,
+        },
+      });
+    }
+  }
+}
+
+async function getCollectionNames(payload: MigrateUpArgs["payload"]) {
+  const db = payload.db.connection.db;
+
+  if (!db) {
+    throw new Error("Missing database connection while listing collections");
+  }
+
+  const collections = await db.listCollections().toArray();
+
+  return collections.map((collection) => collection.name);
+}
+
+function migrateContent(
+  content: unknown,
+  brands: Map<string, BrandDocument>,
+  context: string,
+): { changed: boolean; value: unknown } {
+  if (Array.isArray(content)) {
+    let changed = false;
+    const value = content.map((block, blockIndex) => {
+      const migrated = migrateBlock(
+        block,
+        brands,
+        `${context}/content[${blockIndex}]`,
+      );
+      changed ||= migrated.changed;
+      return migrated.value;
+    });
+
+    return { changed, value };
+  }
+
+  if (isRecord(content)) {
+    let changed = false;
+    const value = Object.fromEntries(
+      Object.entries(content).map(([locale, localeContent]) => {
+        const migrated = migrateContent(
+          localeContent,
+          brands,
+          `${context}/${locale}`,
+        );
+        changed ||= migrated.changed;
+        return [locale, migrated.value];
+      }),
+    );
+
+    return { changed, value };
+  }
+
+  return { changed: false, value: content };
+}
+
+function migrateBlock(
+  block: unknown,
+  brands: Map<string, BrandDocument>,
+  context: string,
+): { changed: boolean; value: unknown } {
+  if (!isRecord(block) || block.blockType !== "AccommodationSelector") {
+    return { changed: false, value: block };
+  }
+
+  if (!Array.isArray(block.cards)) {
+    return { changed: false, value: block };
+  }
+
+  let changed = false;
+  const cards = block.cards.map((card, cardIndex) => {
+    const migrated = migrateCard(
+      card,
+      brands,
+      `${context}/cards[${cardIndex}]`,
+    );
+    changed ||= migrated.changed;
+    return migrated.value;
+  });
+
+  return {
+    changed,
+    value: changed ? { ...block, cards } : block,
+  };
+}
+
+function migrateCard(
+  card: unknown,
+  brands: Map<string, BrandDocument>,
+  context: string,
+): { changed: boolean; value: unknown } {
+  if (!isRecord(card)) {
+    return { changed: false, value: card };
+  }
+
+  if (!("brand" in card)) {
+    return { changed: false, value: card };
+  }
+
+  const brand = resolveBrand(card.brand, brands, context);
+  const title = getRequiredString(brand.name, `${context} brand name`);
+  const color = getRequiredColor(brand.id ?? brand._id, `${context} brand id`);
+
+  if (!isRecord(brand.homeLink)) {
+    throw new Error(`Missing brand homeLink for ${context}`);
+  }
+
+  const { brand: _brand, ...rest } = card;
+
+  return {
+    changed: true,
+    value: {
+      ...rest,
+      title,
+      link: brand.homeLink,
+      color,
+    },
+  };
+}
+
+function resolveBrand(
+  brandReference: unknown,
+  brands: Map<string, BrandDocument>,
+  context: string,
+) {
+  const brandId = getRelationshipId(brandReference);
+  const brand = brandId ? brands.get(brandId) : undefined;
+
+  if (!brand) {
+    throw new Error(
+      `Could not resolve accommodation selector brand for ${context}`,
+    );
+  }
+
+  return brand;
+}
+
+function getRelationshipId(value: unknown): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (isRecord(value)) {
+    return getRelationshipId(value.value ?? value.id ?? value._id);
+  }
+
+  return String(value);
+}
+
+function getRequiredString(value: unknown, context: string) {
+  if (typeof value !== "string" || !value) {
+    throw new Error(`Missing ${context}`);
+  }
+
+  return value;
+}
+
+function getRequiredColor(value: unknown, context: string) {
+  const color = getRequiredString(value, context);
+
+  if (!colorOptions.has(color)) {
+    throw new Error(`Unsupported ${context}: ${color}`);
+  }
+
+  return color;
+}
+
+function getPath(document: Document, path: string) {
+  return path.split(".").reduce<unknown>((value, segment) => {
+    if (!isRecord(value)) {
+      return undefined;
+    }
+
+    return value[segment];
+  }, document);
+}
+
+function isRecord(value: unknown): value is Document {
+  return typeof value === "object" && value !== null;
+}

--- a/apps/cms/src/migrations/index.ts
+++ b/apps/cms/src/migrations/index.ts
@@ -5,6 +5,7 @@ import * as migration_20250719_221257_migration from "./20250719_221257_migratio
 import * as migration_20250724_194253_languages from "./20250724_194253_languages";
 import * as migration_20250817_133906_migration from "./20250817_133906_migration";
 import * as migration_20260529_000000_optional_room_cta from "./20260529_000000_optional_room_cta";
+import * as migration_20260529_224952_accommodation_selector_card_links from "./20260529_224952_accommodation_selector_card_links";
 
 export const migrations = [
   {
@@ -41,5 +42,10 @@ export const migrations = [
     up: migration_20260529_000000_optional_room_cta.up,
     down: migration_20260529_000000_optional_room_cta.down,
     name: "20260529_000000_optional_room_cta",
+  },
+  {
+    up: migration_20260529_224952_accommodation_selector_card_links.up,
+    down: migration_20260529_224952_accommodation_selector_card_links.down,
+    name: "20260529_224952_accommodation_selector_card_links",
   },
 ];

--- a/apps/frontend/app/blocks/accommodation-selector-block.stories.ts
+++ b/apps/frontend/app/blocks/accommodation-selector-block.stories.ts
@@ -3,7 +3,7 @@ import {
   AccommodationSelectorBlock,
   AccommodationSelectorBlockProps,
 } from "./accommodation-selector-block";
-import { brand, internalLink, media } from "~/common/cms-data.builders";
+import { internalLink, media } from "~/common/cms-data.builders";
 import { bold, paragraph, richTextRoot, text } from "@fxmk/common";
 import { createId } from "@paralleldrive/cuid2";
 
@@ -14,6 +14,41 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+const defaultCards: NonNullable<AccommodationSelectorBlockProps["cards"]> = [
+  {
+    id: createId(),
+    title: "Puerta Aqua",
+    link: internalLink("/aqua"),
+    color: "aqua",
+    image: media("Frente.jpg"),
+    description: richTextRoot(
+      paragraph(
+        text(
+          "Stay at our lively hostel in the heart of Santa Marta and meet travelers from all over the world. Our rooftop bar is perfect for a get-together at night.",
+        ),
+      ),
+    ) as unknown as NonNullable<
+      AccommodationSelectorBlockProps["cards"]
+    >[number]["description"],
+  },
+  {
+    id: createId(),
+    title: "La Puerta Azul",
+    link: internalLink("/azul"),
+    color: "azul",
+    image: media("10.jpg"),
+    description: richTextRoot(
+      paragraph(
+        text(
+          "Being one of the oldest houses in Santa Marta, La Puerta Azul is filled with beauty and history. It can also be booked completely as a private six-room villa.",
+        ),
+      ),
+    ) as unknown as NonNullable<
+      AccommodationSelectorBlockProps["cards"]
+    >[number]["description"],
+  },
+];
 
 export const Default: Story = {
   args: {
@@ -26,43 +61,31 @@ export const Default: Story = {
         text(" in Santa Marta."),
       ),
     ) as unknown as AccommodationSelectorBlockProps["text"],
+    cards: defaultCards,
+  },
+};
+
+export const AllColorStyles: Story = {
+  args: {
+    ...Default.args,
+    heading: "Accommodation Card Color Styles",
+    text: richTextRoot(
+      paragraph(text("Preview all available accommodation card palettes.")),
+    ) as unknown as AccommodationSelectorBlockProps["text"],
     cards: [
       {
         id: createId(),
-        brand: brand({
-          id: "aqua",
-          name: "Puerta Aqua",
-          homeLink: internalLink("/aqua"),
-        }),
+        title: "La Puerta",
+        link: internalLink("/"),
+        color: "puerta",
         image: media("Frente.jpg"),
         description: richTextRoot(
-          paragraph(
-            text(
-              "Stay at our lively hostel in the heart of Santa Marta and meet travelers from all over the world. Our rooftop bar is perfect for a get-together at night.",
-            ),
-          ),
+          paragraph(text("Use the Puerta palette for umbrella brand pages.")),
         ) as unknown as NonNullable<
           AccommodationSelectorBlockProps["cards"]
         >[number]["description"],
       },
-      {
-        id: createId(),
-        brand: brand({
-          id: "azul",
-          name: "La Puerta Azul",
-          homeLink: internalLink("/azul"),
-        }),
-        image: media("10.jpg"),
-        description: richTextRoot(
-          paragraph(
-            text(
-              "Being one of the oldest houses in Santa Marta, La Puerta Azul is filled with beauty and history. It can also be booked completely as a private six-room villa.",
-            ),
-          ),
-        ) as unknown as NonNullable<
-          AccommodationSelectorBlockProps["cards"]
-        >[number]["description"],
-      },
+      ...defaultCards,
     ],
   },
 };

--- a/apps/frontend/app/blocks/accommodation-selector-block.tsx
+++ b/apps/frontend/app/blocks/accommodation-selector-block.tsx
@@ -2,11 +2,8 @@ import { RichTextObject } from "@fxmk/common";
 import { cn } from "../common/cn";
 import { Heading } from "../common/heading";
 import { RichTextParagraph } from "../common/paragraph";
-import { BrandId } from "~/brands";
 import { MediaImage } from "~/common/media";
 import { PageLink } from "~/common/page-link";
-import { ReactNode } from "react";
-import { gracefully } from "~/common/utils";
 import { AccommodationSelector } from "@lapuertahostels/payload-types";
 
 export type AccommodationSelectorBlockProps = Partial<AccommodationSelector>;
@@ -39,7 +36,7 @@ export function AccommodationSelectorBlock({
             {text as RichTextObject | undefined}
           </RichTextParagraph>
         </div>
-        <div className="mx-auto mt-8 grid max-w-7xl grid-rows-2 gap-16 px-0 md:mt-14 md:grid-cols-2 md:grid-rows-none md:gap-8 md:px-8">
+        <div className="mx-auto mt-8 grid max-w-7xl grid-cols-1 gap-16 px-0 md:mt-14 md:grid-cols-2 md:gap-8 md:px-8">
           {cards?.map((card) => (
             <AccommodationCard key={card.id} {...card} />
           ))}
@@ -54,34 +51,23 @@ type AccommodationCardProps = NonNullable<
 >[number];
 
 function AccommodationCard({
-  brand,
+  color,
   description,
   image,
+  link,
+  title,
 }: AccommodationCardProps) {
-  const brandId = gracefully(brand, "id") as BrandId | undefined;
-
   const componentClassName = cn(
     "group flex flex-col overflow-hidden shadow-lg hover:shadow-md md:rounded-xl",
     {
-      "bg-aqua-600 hover:bg-aqua-200": brandId === "aqua",
-      "bg-azul-600 hover:bg-azul-200": brandId === "azul",
-      "bg-neutral-600": !brandId,
+      "bg-puerta-600 hover:bg-puerta-200": color === "puerta",
+      "bg-aqua-600 hover:bg-aqua-200": color === "aqua",
+      "bg-azul-600 hover:bg-azul-200": color === "azul",
     },
   );
 
-  function getComponent(children: ReactNode) {
-    const homeLink = gracefully(brand, "homeLink");
-    return homeLink ? (
-      <PageLink link={homeLink} className={componentClassName}>
-        {children}
-      </PageLink>
-    ) : (
-      <div className={componentClassName}>{children}</div>
-    );
-  }
-
-  return getComponent(
-    <>
+  return (
+    <PageLink link={link} className={componentClassName}>
       <div className="relative aspect-1/1 overflow-hidden bg-white sm:aspect-4/3 md:aspect-1/1 lg:aspect-4/3 xl:aspect-16/9">
         <MediaImage
           media={image}
@@ -99,17 +85,18 @@ function AccommodationCard({
       </div>
       <div
         className={cn("space-y-1 px-8 py-4 text-white md:space-y-2 md:px-6", {
-          "group-hover:text-azul-800": brandId === "azul",
-          "group-hover:text-aqua-800": brandId === "aqua",
+          "group-hover:text-puerta-800": color === "puerta",
+          "group-hover:text-azul-800": color === "azul",
+          "group-hover:text-aqua-800": color === "aqua",
         })}
       >
         <Heading as="h4" variant="inherit" size="extra-small">
-          {gracefully(brand, "name")}
+          {title}
         </Heading>
         <RichTextParagraph variant="inherit" justify>
           {description as unknown as RichTextObject | undefined}
         </RichTextParagraph>
       </div>
-    </>,
+    </PageLink>
   );
 }

--- a/apps/frontend/app/common/page-link.tsx
+++ b/apps/frontend/app/common/page-link.tsx
@@ -1,4 +1,4 @@
-import { Brand, NewLink } from "@lapuertahostels/payload-types";
+import { NewLink } from "@lapuertahostels/payload-types";
 import { Link, LinkProps } from "./link";
 import { PropsWithChildren } from "react";
 import { gracefully, isObject } from "./utils";
@@ -6,7 +6,7 @@ import { buildLocalizedRelativeUrl } from "./routing";
 import { useTranslation } from "react-i18next";
 
 export type PageLinkProps = {
-  link?: NonNullable<Brand["navLinks"]>[number]["link"] | null;
+  link?: NewLink | null;
 } & Omit<PropsWithChildren<LinkProps>, "to">;
 
 export function PageLink({ link, ...props }: PageLinkProps) {

--- a/apps/frontend/app/layout/page.stories.tsx
+++ b/apps/frontend/app/layout/page.stories.tsx
@@ -1,12 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Page } from "./page";
 import { ThemeProvider } from "~/themes";
-import {
-  brand,
-  callToAction,
-  internalLink,
-  media,
-} from "~/common/cms-data.builders";
+import { callToAction, internalLink, media } from "~/common/cms-data.builders";
 import { createId } from "@paralleldrive/cuid2";
 import { bold, paragraph, richTextRoot, text } from "@fxmk/common";
 import { Brand, Page as PageItem } from "@lapuertahostels/payload-types";
@@ -137,11 +132,9 @@ export const Puerta: Story = {
           cards: [
             {
               id: createId(),
-              brand: brand({
-                id: "aqua",
-                name: "Puerta Aqua",
-                homeLink: internalLink("/aqua"),
-              }),
+              title: "Puerta Aqua",
+              link: internalLink("/aqua"),
+              color: "aqua",
               image: media("Frente.jpg"),
               description: richTextRoot(
                 paragraph(
@@ -153,11 +146,9 @@ export const Puerta: Story = {
             },
             {
               id: createId(),
-              brand: brand({
-                id: "azul",
-                name: "La Puerta Azul",
-                homeLink: internalLink("/azul"),
-              }),
+              title: "La Puerta Azul",
+              link: internalLink("/azul"),
+              color: "azul",
               image: media("10.jpg"),
               description: richTextRoot(
                 paragraph(


### PR DESCRIPTION
## Summary

- refactor Accommodation Selector cards to use explicit title, link, and color fields instead of deriving those from a brand relationship
- update the frontend renderer and Storybook fixtures for flexible card counts and all brand palettes
- add a Payload migration that converts existing brand-backed cards to the new standalone card model

## Context

Editors need Accommodation Selector cards to link to arbitrary CMS link targets, not only the selected brand's home link. This moves navigation and visual style into the card itself while preserving existing rendered content through migration.

## Impact

Editors can now link Accommodation Selector cards to any supported `linkField()` target while choosing the card palette directly. Existing content is migrated from brand references using the brand name, home link, and brand id.

## Risks and Mitigations

- Migration safety: the migration fails clearly if an existing card cannot resolve its brand, brand name, brand home link, or supported color instead of silently writing bad links.
- Migration ordering: this PR's migration uses `20260529_224952` so it runs after the `20260529_000000_optional_room_cta` migration already on `main`.
- Rendering compatibility: Storybook fixtures cover the existing Aqua/Azul cards plus a new all-color variant for Puerta/Aqua/Azul palettes.

## Validation

- `pnpm --filter @lapuertahostels/payload-types pull-payload-types`
- `pnpm --filter @lapuertahostels/cms build`
- `pnpm --filter @lapuertahostels/cms lint`
- `pnpm --filter @lapuertahostels/cms check-format`
- `pnpm --filter @lapuertahostels/frontend typecheck`
- `pnpm --filter @lapuertahostels/frontend lint`
- `pnpm --filter @lapuertahostels/frontend test`
- `pnpm --filter @lapuertahostels/frontend check-format`
- GitHub Actions checks are passing, including e2e and Chromatic publish.

## Known Limitations

- Storybook started and registered the new all-colors story locally, but a headless screenshot check could not run in the fresh local environment because Playwright's browser binary was not installed.