### PR TITLE
chore(deps): upgrade webplatform to 0.9

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -17,7 +17,7 @@
     "check-format": "prettier --check ."
   },
   "dependencies": {
-    "@fxmk/cms-plugin": "0.8.1",
+    "@fxmk/cms-plugin": "0.9.0",
     "@payloadcms/db-mongodb": "^3.84.1",
     "@payloadcms/email-resend": "^3.84.1",
     "@payloadcms/next": "^3.84.1",

--- a/apps/cms/src/migrations/20260606_210000_migrate_brand_theme_colors.ts
+++ b/apps/cms/src/migrations/20260606_210000_migrate_brand_theme_colors.ts
@@ -1,0 +1,21 @@
+import { migrateBrandThemeColors } from "@fxmk/cms-plugin";
+import { MigrateDownArgs, MigrateUpArgs } from "@payloadcms/db-mongodb";
+
+export async function up({ payload, req }: MigrateUpArgs): Promise<void> {
+  const result = await migrateBrandThemeColors({
+    payload,
+    req,
+    defaultThemeColor: "puerta",
+    themeColorByBrandId: {
+      puerta: "puerta",
+      aqua: "aqua",
+      azul: "azul",
+    },
+  });
+
+  console.log("Migrated brand theme colors", result);
+}
+
+export async function down(_: MigrateDownArgs): Promise<void> {
+  // Migration code
+}

--- a/apps/cms/src/migrations/index.ts
+++ b/apps/cms/src/migrations/index.ts
@@ -7,6 +7,7 @@ import * as migration_20250817_133906_migration from "./20250817_133906_migratio
 import * as migration_20260529_000000_optional_room_cta from "./20260529_000000_optional_room_cta";
 import * as migration_20260529_224952_accommodation_selector_card_links from "./20260529_224952_accommodation_selector_card_links";
 import * as migration_20260606_194625_migrate_brand_root_paths from "./20260606_194625_migrate_brand_root_paths";
+import * as migration_20260606_210000_migrate_brand_theme_colors from "./20260606_210000_migrate_brand_theme_colors";
 
 export const migrations = [
   {
@@ -53,5 +54,10 @@ export const migrations = [
     up: migration_20260606_194625_migrate_brand_root_paths.up,
     down: migration_20260606_194625_migrate_brand_root_paths.down,
     name: "20260606_194625_migrate_brand_root_paths",
+  },
+  {
+    up: migration_20260606_210000_migrate_brand_theme_colors.up,
+    down: migration_20260606_210000_migrate_brand_theme_colors.down,
+    name: "20260606_210000_migrate_brand_theme_colors",
   },
 ];

--- a/apps/cms/src/payload.config.ts
+++ b/apps/cms/src/payload.config.ts
@@ -65,6 +65,11 @@ export default buildConfig({
       livePreviewBaseUrl: process.env.LIVE_PREVIEW_URL,
       serverUrl: process.env.SERVER_URL,
       e2eTestsApiKey: process.env.E2E_TESTS_API_KEY,
+      themeColors: [
+        { label: { en: "Puerta", es: "Puerta" }, value: "puerta" },
+        { label: { en: "Aqua", es: "Aqua" }, value: "aqua" },
+        { label: { en: "Azul", es: "Azul" }, value: "azul" },
+      ],
     }),
   ],
   db: mongooseAdapter({

--- a/apps/frontend/.storybook/preview.tsx
+++ b/apps/frontend/.storybook/preview.tsx
@@ -98,7 +98,7 @@ const preview: Preview = {
     withReactRouter,
     (Story, { globals, parameters }) => (
       <I18nextProvider i18n={parameters.i18n}>
-        <ThemeProvider brandId={globals.brand}>
+        <ThemeProvider themeColor={globals.brand}>
           <Story />
         </ThemeProvider>
       </I18nextProvider>

--- a/apps/frontend/app/common/brand-logo.tsx
+++ b/apps/frontend/app/common/brand-logo.tsx
@@ -1,7 +1,6 @@
 import { Brand } from "@lapuertahostels/payload-types";
-import { type BrandId } from "../brands";
 import { cn } from "./cn";
-import { themesByBrand } from "~/themes";
+import { getTheme } from "~/themes";
 import { MediaImage } from "./media";
 
 export type BrandLogoProps = {
@@ -17,7 +16,7 @@ export function BrandLogo({
   type = "with-wordmark",
   className,
 }: BrandLogoProps) {
-  const theme = themesByBrand[brand.id as BrandId];
+  const theme = getTheme(brand.themeColor);
   return (
     <span
       className={cn(

--- a/apps/frontend/app/common/cms-data.builders.ts
+++ b/apps/frontend/app/common/cms-data.builders.ts
@@ -16,6 +16,7 @@ export function brand(values: Partial<Brand> = {}): Brand {
     name: values.name ?? "La Puerta Hostels",
     homeLink: values.homeLink ?? internalLink("/"),
     rootPath: values.rootPath ?? "/",
+    themeColor: values.themeColor ?? "puerta",
     navLinks: values.navLinks ?? [],
     logo: values.logo ?? media("logo-puerta-simple.png"),
     createdAt: date,

--- a/apps/frontend/app/global-error-boundary.tsx
+++ b/apps/frontend/app/global-error-boundary.tsx
@@ -63,7 +63,7 @@ export function GlobalErrorBoundary() {
         <AnalyticsScript analyticsDomain={analyticsDomain} />
       </head>
       <body className="bg-white text-neutral-900 antialiased">
-        <ThemeProvider brandId="puerta">
+        <ThemeProvider themeColor={brand.themeColor}>
           <Header
             brand={brand}
             allBrands={allBrands}
@@ -135,7 +135,7 @@ function MaintenanceErrorScreen({ settings }: { settings: Settings }) {
         <Links />
       </head>
       <body className="bg-white text-neutral-900 antialiased">
-        <ThemeProvider brandId="puerta">
+        <ThemeProvider themeColor="puerta">
           <MaintenanceScreen {...settings.maintenanceScreen!} />
           <Scripts />
         </ThemeProvider>

--- a/apps/frontend/app/layout/page.stories.tsx
+++ b/apps/frontend/app/layout/page.stories.tsx
@@ -23,7 +23,7 @@ export const Puerta: Story = {
   decorators: [
     // override the brand context, this is a Puerta-only component
     (Story) => (
-      <ThemeProvider brandId="puerta">
+      <ThemeProvider themeColor="puerta">
         <Story />
       </ThemeProvider>
     ),
@@ -247,7 +247,7 @@ export const Aqua: Story = {
   decorators: [
     // override the brand context, this is a Aqua-only component
     (Story) => (
-      <ThemeProvider brandId="aqua">
+      <ThemeProvider themeColor="aqua">
         <Story />
       </ThemeProvider>
     ),
@@ -394,7 +394,7 @@ export const Azul: Story = {
   decorators: [
     // override the brand context, this is a Azul-only component
     (Story) => (
-      <ThemeProvider brandId="azul">
+      <ThemeProvider themeColor="azul">
         <Story />
       </ThemeProvider>
     ),

--- a/apps/frontend/app/root.tsx
+++ b/apps/frontend/app/root.tsx
@@ -207,7 +207,7 @@ export default function App() {
           }
           region={settings.maps?.region || undefined}
         >
-          <ThemeProvider brandId={brand.id as BrandId}>
+          <ThemeProvider themeColor={brand.themeColor}>
             {settings.maintenanceScreen?.show && isAuthorized && (
               <PreviewBar adminLocale={adminLocale!} />
             )}

--- a/apps/frontend/app/themes.tsx
+++ b/apps/frontend/app/themes.tsx
@@ -1,5 +1,4 @@
 import { PropsWithChildren, createContext, useContext } from "react";
-import { BrandId } from "./brands";
 
 export type Theme = {
   loadingBarColor: string;
@@ -38,14 +37,14 @@ export type Theme = {
 };
 
 export type ThemeProviderProps = {
-  brandId: BrandId;
+  themeColor: ThemeColor | null | undefined;
 };
 
 export function ThemeProvider({
-  brandId,
+  themeColor,
   children,
 }: PropsWithChildren<ThemeProviderProps>) {
-  const theme = themesByBrand[brandId];
+  const theme = getTheme(themeColor);
 
   return (
     <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
@@ -63,7 +62,17 @@ export function useTheme() {
   return theme;
 }
 
-export const themesByBrand: Record<BrandId, Theme> = {
+export type ThemeColor = "puerta" | "aqua" | "azul";
+
+export function isThemeColor(value: unknown): value is ThemeColor {
+  return value === "puerta" || value === "aqua" || value === "azul";
+}
+
+export function getTheme(themeColor: unknown) {
+  return themesByBrand[isThemeColor(themeColor) ? themeColor : "puerta"];
+}
+
+export const themesByBrand: Record<ThemeColor, Theme> = {
   puerta: {
     loadingBarColor: "bg-puerta-500",
     logoTextColor: "text-neutral-900",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -15,7 +15,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@fxmk/common": "0.8.1",
+    "@fxmk/common": "0.9.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@lapuertahostels/payload-types": "workspace:../../libs/payload-types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
   apps/cms:
     dependencies:
       '@fxmk/cms-plugin':
-        specifier: 0.8.1
-        version: 0.8.1(128199f210e2ca31efa9dd2040f35b6b)
+        specifier: 0.9.0
+        version: 0.9.0(128199f210e2ca31efa9dd2040f35b6b)
       '@payloadcms/db-mongodb':
         specifier: ^3.84.1
         version: 3.84.1(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))
@@ -106,8 +106,8 @@ importers:
   apps/frontend:
     dependencies:
       '@fxmk/common':
-        specifier: 0.8.1
-        version: 0.8.1
+        specifier: 0.9.0
+        version: 0.9.0
       '@headlessui/react':
         specifier: ^2.2.10
         version: 2.2.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -278,8 +278,8 @@ importers:
   tests/e2e:
     devDependencies:
       '@fxmk/common':
-        specifier: 0.8.1
-        version: 0.8.1
+        specifier: 0.9.0
+        version: 0.9.0
       '@lapuertahostels/payload-types':
         specifier: workspace:../../libs/payload-types
         version: link:../../libs/payload-types
@@ -1228,8 +1228,8 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@fxmk/cms-plugin@0.8.1':
-    resolution: {integrity: sha512-Fiiac9YLqwB0jqJING2y9zH+XKgh6BwjfwoDHQRg6V1LCXSGO0Hhycb3H+A1etkXxbaxoV5qzLrbSk0u8DplvQ==}
+  '@fxmk/cms-plugin@0.9.0':
+    resolution: {integrity: sha512-xlm91uZImEr0uRhpFIU+Wo31q0QtZ61diDHzvhiYs+Wt+EI7pItsCzbs6CSayyfEeq8DjHZ4tfwo6z+8gaJJHw==}
     engines: {node: '>=24.0.0', pnpm: ^9 || ^10 || ^11}
     peerDependencies:
       '@payloadcms/db-mongodb': ^3.84.1
@@ -1241,8 +1241,8 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@fxmk/common@0.8.1':
-    resolution: {integrity: sha512-p4e2KopHvHjraqad+gLi2AWBsOCbH8ZyCLmTsme2a1gNzBPEQcjwdUML30L35HylcYxv0ym4Trllr3BpwCDWug==}
+  '@fxmk/common@0.9.0':
+    resolution: {integrity: sha512-ffbdbzAcGFX7N/b9oBqj0jmtba5mQYkgywOW/I2oy+x/3jNBXiBrUE34UJQ6X8dBIe2GPMF4M+3Ftpbu+tdJSg==}
 
   '@fxmk/releaser@0.5.4':
     resolution: {integrity: sha512-xSFlL59FyN+kOeRRRHUJqCE4tbM2/vMS2SK9fjdh9UH69ct3vPIw+mU5Is6wNdRPhHVcP/HVAVljugwEbsHiqQ==}
@@ -8093,7 +8093,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fxmk/cms-plugin@0.8.1(128199f210e2ca31efa9dd2040f35b6b)':
+  '@fxmk/cms-plugin@0.9.0(128199f210e2ca31efa9dd2040f35b6b)':
     dependencies:
       '@payloadcms/db-mongodb': 3.84.1(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))
       '@payloadcms/richtext-lexical': 3.84.1(@faceless-ui/modal@3.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@payloadcms/next@3.84.1(@types/react@19.2.15)(graphql@16.10.0)(monaco-editor@0.52.2)(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4))(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@types/react@19.2.15)(monaco-editor@0.52.2)(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4))(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)(yjs@13.6.23)
@@ -8115,7 +8115,7 @@ snapshots:
       - debug
       - ws
 
-  '@fxmk/common@0.8.1': {}
+  '@fxmk/common@0.9.0': {}
 
   '@fxmk/releaser@0.5.4':
     dependencies:

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@fxmk/common": "0.8.1",
+    "@fxmk/common": "0.9.0",
     "@lapuertahostels/payload-types": "workspace:../../libs/payload-types",
     "@paralleldrive/cuid2": "^3.3.0",
     "@playwright/test": "^1.60.0",


### PR DESCRIPTION
## Context

Webplatform `0.9.0` adds explicit brand theme-color support in `@fxmk/cms-plugin`. La Puerta Hostels previously inferred frontend theme selection from `brand.id`, which couples visual theming to brand identity and misses the new CMS model.

## Changes

- Upgrade `@fxmk/cms-plugin` and `@fxmk/common` to `0.9.0`.
- Configure CMS `themeColors` for Puerta, Aqua, and Azul.
- Add a Payload migration to backfill `brand.themeColor` for existing brands.
- Switch frontend theme lookup to `brand.themeColor`, including app rendering, error pages, Storybook decorators, and shared logo styling.

## Risks and Mitigations

- Existing brand documents need the migration before relying on `themeColor`; this PR maps current brand IDs directly to matching theme tokens and defaults unknown brands to `puerta`.
- Generated Payload types are gitignored in this repo, so type generation is validated locally and in CI rather than committed.
- The new webplatform media folder options are intentionally not enabled; current media category behavior remains unchanged.

## Validation

- `pnpm --filter @lapuertahostels/cms build`
- `pnpm --filter @lapuertahostels/payload-types pull-payload-types`
- `pnpm --filter @lapuertahostels/frontend typecheck`
- `pnpm --filter @lapuertahostels/frontend lint`
- `pnpm --filter @lapuertahostels/frontend test`
- `pnpm --filter @lapuertahostels/frontend check-format`
- `pnpm --filter @lapuertahostels/cms lint`
- `pnpm --filter @lapuertahostels/cms check-format`

## Follow-ups

- None planned.