### PR TITLE
chore(docker): improve build cache and version args

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: "Build"
-    uses: fxmkdev/webplatform/.github/workflows/export.build.yml@v0.9.1
+    uses: fxmkdev/webplatform/.github/workflows/export.build.yml@v0.9.2
     permissions:
       contents: write
     secrets: inherit

--- a/.github/workflows/clean-preview.yml
+++ b/.github/workflows/clean-preview.yml
@@ -7,5 +7,5 @@ on:
 jobs:
   clean-preview:
     name: Clean Preview
-    uses: fxmkdev/webplatform/.github/workflows/export.clean-preview.yml@v0.9.1
+    uses: fxmkdev/webplatform/.github/workflows/export.clean-preview.yml@v0.9.2
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   deploy:
     name: "Deploy"
-    uses: fxmkdev/webplatform/.github/workflows/export.deploy.yml@v0.9.1
+    uses: fxmkdev/webplatform/.github/workflows/export.deploy.yml@v0.9.2
     with:
       environment: ${{ inputs.environment }}
     secrets: inherit

--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -21,7 +21,7 @@ RUN corepack enable pnpm
 COPY --link package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY --link apps/cms/package.json apps/cms/
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
-    pnpm --filter @lapuertahostels/cms install --frozen-lockfile --store-dir /pnpm/store
+    pnpm --config.store-dir=/pnpm/store --filter @lapuertahostels/cms install --frozen-lockfile
 
 # Copy application code
 COPY apps/cms apps/cms

--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -1,3 +1,5 @@
+# syntax = docker/dockerfile:1
+
 # From https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
 FROM node:24-alpine AS base
@@ -7,6 +9,7 @@ RUN npm install -g corepack@latest
 
 # Install dependencies only when needed
 FROM base AS builder
+ARG APP_VERSION=0.0.0-unknown
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -16,8 +19,12 @@ RUN corepack enable pnpm
 
 # Install dependencies
 COPY --link package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY --link apps/cms apps/cms
-RUN pnpm --filter cms install --frozen-lockfile
+COPY --link apps/cms/package.json apps/cms/
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
+    pnpm --filter @lapuertahostels/cms install --frozen-lockfile --store-dir /pnpm/store
+
+# Copy application code
+COPY apps/cms apps/cms
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
@@ -25,6 +32,7 @@ RUN pnpm --filter cms install --frozen-lockfile
 # ENV NEXT_TELEMETRY_DISABLED 1
 
 RUN pnpm --dir apps/cms build
+RUN node -e "const fs = require('fs'); const [file, version] = process.argv.slice(1); const pkg = JSON.parse(fs.readFileSync(file, 'utf8')); pkg.version = version; fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + '\n');" apps/cms/.next/standalone/apps/cms/package.json "$APP_VERSION"
 
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/apps/cms/Dockerfile.dockerignore
+++ b/apps/cms/Dockerfile.dockerignore
@@ -12,9 +12,14 @@
 **/.next
 **/.react-router
 **/build
+**/coverage
+**/playwright-report
+**/storybook-static
+**/.cache
 **/node_modules
 **/tests
 **/.env*
 **/tsconfig.tsbuildinfo
+**/*.log
 **/.vscode
 **/.DS_Store

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -19,6 +19,7 @@ RUN corepack enable pnpm
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build
+ARG APP_VERSION=0.0.0-unknown
 ENV CI=true
 
 # Install packages needed to build node modules
@@ -28,17 +29,23 @@ RUN apt-get update -qq && \
 # Install node modules
 COPY --link package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY --link apps/frontend/package.json apps/frontend/
-RUN pnpm --filter frontend install --prod=false --frozen-lockfile
+COPY --link libs/payload-types/package.json libs/payload-types/
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
+    pnpm --filter @lapuertahostels/frontend install --prod=false --frozen-lockfile --store-dir /pnpm/store
 
 # Copy application code
-COPY --link apps/frontend apps/frontend
-COPY --link libs/payload-types libs/payload-types
+COPY apps/frontend apps/frontend
+COPY libs/payload-types libs/payload-types
+
+# React Router bundles the imported package JSON during the build.
+RUN node -e "const fs = require('fs'); const [file, version] = process.argv.slice(1); const pkg = JSON.parse(fs.readFileSync(file, 'utf8')); pkg.version = version; fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + '\n');" apps/frontend/package.json "$APP_VERSION"
 
 # Build application
-RUN pnpm --filter frontend build
+RUN cd apps/frontend && ./node_modules/.bin/react-router build
 
 # Remove development dependencies
-RUN pnpm --dir apps/frontend prune --prod
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
+    pnpm --config.store-dir=/pnpm/store --dir apps/frontend prune --prod
 
 
 # Final stage for app image

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -31,7 +31,7 @@ COPY --link package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY --link apps/frontend/package.json apps/frontend/
 COPY --link libs/payload-types/package.json libs/payload-types/
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
-    pnpm --filter @lapuertahostels/frontend install --prod=false --frozen-lockfile --store-dir /pnpm/store
+    pnpm --config.store-dir=/pnpm/store --filter @lapuertahostels/frontend install --prod=false --frozen-lockfile
 
 # Copy application code
 COPY apps/frontend apps/frontend
@@ -56,4 +56,4 @@ COPY --from=build /app /app
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
-CMD [ "pnpm", "--filter", "frontend", "start" ]
+CMD [ "pnpm", "--filter", "@lapuertahostels/frontend", "start" ]

--- a/apps/frontend/Dockerfile.dockerignore
+++ b/apps/frontend/Dockerfile.dockerignore
@@ -13,9 +13,14 @@
 **/.next
 **/.react-router
 **/build
+**/coverage
+**/playwright-report
+**/storybook-static
+**/.cache
 **/node_modules
 **/tests
 **/.env*
 **/tsconfig.tsbuildinfo
+**/*.log
 **/.vscode
 **/.DS_Store


### PR DESCRIPTION
## Summary

- Split frontend and CMS Docker dependency install layers from source copy layers.
- Add BuildKit pnpm store cache mounts for Docker installs and frontend production pruning.
- Move release version stamping into Docker via `APP_VERSION`.
- Pin reusable webplatform workflows to `v0.9.2`, which includes the build-arg/cache workflow updates needed by these Dockerfiles.
- Tighten per-Dockerfile ignore files for generated outputs, caches, reports, and logs.

## Validation

- CI is green on rebased head `78600ee`:
  - Frontend typecheck, lint, unit tests, format, build/push, and Chromatic publish.
  - CMS lint, format, build/push.
  - Populate CMS types.
  - End-to-end tests.
  - Preview deploy and clean-preview jobs.
- Earlier local Docker validation:
  - `DOCKER_BUILDKIT=1 docker build -f apps/frontend/Dockerfile --build-arg APP_VERSION=2026.6.8-review -t lapuertahostels-frontend:review .`
  - Ran the frontend image and verified `GET /api/version` returned `{"version":"2026.6.8-review"}`.
  - `DOCKER_BUILDKIT=1 docker build -f apps/cms/Dockerfile --build-arg APP_VERSION=2026.6.8-review -t lapuertahostels-cms:review .`
  - `docker run --rm lapuertahostels-cms:review node -e 'console.log(require("./apps/cms/.next/standalone/apps/cms/package.json").version)'` printed `2026.6.8-review`.

## Risks and mitigations

- The frontend reads `package.json` during the React Router build, so the Dockerfile writes `APP_VERSION` before `react-router build`.
- The CMS standalone package metadata can be stamped after the expensive Next build, preserving build-layer caching.
- The CMS Docker build still emits Docker's existing shell-form `CMD` warning; this PR does not change that runtime command.

## Follow-ups

- None currently planned.