### PR TITLE
[codex] fix(frontend): make redis cache resume-safe

### DIFF
--- a/apps/frontend/app/cms-data.server.test.ts
+++ b/apps/frontend/app/cms-data.server.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { purgeCache, tryGetPage } from "./cms-data.server";
 
 const runRedisCommand = vi.hoisted(() => vi.fn());
@@ -33,6 +33,11 @@ beforeEach(() => {
   vi.stubEnv("PAYLOAD_CMS_API_KEY", "test-api-key");
   vi.stubGlobal("fetch", fetchMock);
   runRedisCommand.mockImplementation((command) => command(redis));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
 });
 
 describe("CMS data cache", () => {

--- a/apps/frontend/app/cms-data.server.test.ts
+++ b/apps/frontend/app/cms-data.server.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { purgeCache, tryGetPage } from "./cms-data.server";
+
+const runRedisCommand = vi.hoisted(() => vi.fn());
+
+vi.mock("./redis", () => ({
+  runRedisCommand,
+}));
+
+type MockRedisClient = {
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  del: ReturnType<typeof vi.fn>;
+  flushDb: ReturnType<typeof vi.fn>;
+};
+
+const redis = {
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+  flushDb: vi.fn(),
+} satisfies MockRedisClient;
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  runRedisCommand.mockReset();
+  redis.get.mockReset();
+  redis.set.mockReset();
+  redis.del.mockReset();
+  redis.flushDb.mockReset();
+  fetchMock.mockReset();
+  vi.stubEnv("PAYLOAD_CMS_BASE_URL", "https://cms.example.com");
+  vi.stubEnv("PAYLOAD_CMS_API_KEY", "test-api-key");
+  vi.stubGlobal("fetch", fetchMock);
+  runRedisCommand.mockImplementation((command) => command(redis));
+});
+
+describe("CMS data cache", () => {
+  test("treats Redis get failures as cache misses and loads from the CMS", async () => {
+    const page = { id: "page-1", pathname: "/about" };
+    redis.get.mockRejectedValue(new Error("Redis unavailable"));
+    redis.set.mockResolvedValue("OK");
+    fetchMock.mockResolvedValue(createJsonResponse({ docs: [page] }));
+
+    await expect(
+      tryGetPage(new Request("https://www.example.com/about"), "/about", "en"),
+    ).resolves.toBe(page);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(redis.set).toHaveBeenCalledTimes(1);
+  });
+
+  test("continues returning CMS data when Redis set fails", async () => {
+    const page = { id: "page-1", pathname: "/about" };
+    redis.get.mockResolvedValue(null);
+    redis.set.mockRejectedValue(new Error("Redis write failed"));
+    fetchMock.mockResolvedValue(createJsonResponse({ docs: [page] }));
+
+    await expect(
+      tryGetPage(new Request("https://www.example.com/about"), "/about", "en"),
+    ).resolves.toBe(page);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(redis.set).toHaveBeenCalledTimes(1);
+  });
+
+  test("continues returning null when Redis delete fails for missing CMS data", async () => {
+    redis.get.mockResolvedValue(null);
+    redis.del.mockRejectedValue(new Error("Redis delete failed"));
+    fetchMock.mockResolvedValue(createJsonResponse({ docs: [] }));
+
+    await expect(
+      tryGetPage(
+        new Request("https://www.example.com/missing"),
+        "/missing",
+        "en",
+      ),
+    ).resolves.toBeNull();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(redis.del).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws when cache purge fails", async () => {
+    const error = new Error("Redis flush failed");
+    redis.flushDb.mockRejectedValue(error);
+
+    await expect(purgeCache()).rejects.toThrow(error);
+  });
+});
+
+function createJsonResponse(data: unknown) {
+  return {
+    ok: true,
+    json: async () => data,
+  } as Response;
+}

--- a/apps/frontend/app/cms-data.server.ts
+++ b/apps/frontend/app/cms-data.server.ts
@@ -31,7 +31,7 @@ async function loadAndCacheData<TData, TResult>(
   return result;
 }
 
-async function cacheData(cacheKeyWithLocale: string, data: object) {
+async function cacheData<TData>(cacheKeyWithLocale: string, data: TData) {
   console.log(`Caching data to ${cacheKeyWithLocale}`);
 
   try {
@@ -41,7 +41,7 @@ async function cacheData(cacheKeyWithLocale: string, data: object) {
         JSON.stringify({
           data,
           cachedAt: new Date().toJSON(),
-        } as CacheEntry<object>),
+        } as CacheEntry<TData>),
       ),
     );
   } catch (error) {

--- a/apps/frontend/app/cms-data.server.ts
+++ b/apps/frontend/app/cms-data.server.ts
@@ -7,7 +7,7 @@ import {
   Footer,
 } from "@lapuertahostels/payload-types";
 import { BRANDS_DEPTH, PAGE_DEPTH } from "./cms-data";
-import { redis } from "./redis";
+import { runRedisCommand } from "./redis";
 
 const CACHE_EXPIRY_IN_MS = 1000 * 60; // 1 min
 
@@ -25,7 +25,7 @@ async function loadAndCacheData<TData, TResult>(
     await cacheData(cacheKeyWithLocale, result);
   } else {
     console.log(`Deleting data for ${cacheKeyWithLocale} (if exists)`);
-    await redis.del(cacheKeyWithLocale);
+    await deleteCachedData(cacheKeyWithLocale);
   }
 
   return result;
@@ -34,13 +34,42 @@ async function loadAndCacheData<TData, TResult>(
 async function cacheData(cacheKeyWithLocale: string, data: object) {
   console.log(`Caching data to ${cacheKeyWithLocale}`);
 
-  await redis.set(
-    cacheKeyWithLocale,
-    JSON.stringify({
-      data,
-      cachedAt: new Date().toJSON(),
-    } as CacheEntry<object>),
-  );
+  try {
+    await runRedisCommand((redis) =>
+      redis.set(
+        cacheKeyWithLocale,
+        JSON.stringify({
+          data,
+          cachedAt: new Date().toJSON(),
+        } as CacheEntry<object>),
+      ),
+    );
+  } catch (error) {
+    console.warn(
+      `Failed to cache data for ${cacheKeyWithLocale}. Continuing without Redis cache: ${formatError(error)}`,
+    );
+  }
+}
+
+async function deleteCachedData(cacheKeyWithLocale: string) {
+  try {
+    await runRedisCommand((redis) => redis.del(cacheKeyWithLocale));
+  } catch (error) {
+    console.warn(
+      `Failed to delete cache entry for ${cacheKeyWithLocale}. Continuing without Redis cache: ${formatError(error)}`,
+    );
+  }
+}
+
+async function getCachedData(cacheKeyWithLocale: string) {
+  try {
+    return await runRedisCommand((redis) => redis.get(cacheKeyWithLocale));
+  } catch (error) {
+    console.warn(
+      `Failed to read cache for ${cacheKeyWithLocale}. Treating as cache miss: ${formatError(error)}`,
+    );
+    return null;
+  }
 }
 
 type CacheEntry<T> = {
@@ -67,7 +96,7 @@ async function getData<TData, TResult>(
     return getResultFn(await loadData(pathname, locale, depth, queryParams));
   }
 
-  const cacheEntryString = await redis.get(cacheKeyWithLocale);
+  const cacheEntryString = await getCachedData(cacheKeyWithLocale);
   const cacheEntry = cacheEntryString
     ? (JSON.parse(cacheEntryString) as CacheEntry<TResult>)
     : null;
@@ -268,5 +297,9 @@ export async function getBrands(request: Request, locale: string) {
 }
 
 export async function purgeCache() {
-  await redis.flushDb();
+  await runRedisCommand((redis) => redis.flushDb());
+}
+
+function formatError(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/frontend/app/redis.test.ts
+++ b/apps/frontend/app/redis.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { closeRedisClient, runRedisCommand } from "./redis";
 
 const createClient = vi.hoisted(() => vi.fn());
@@ -20,6 +20,10 @@ beforeEach(async () => {
   await closeRedisClient();
   createClient.mockReset();
   vi.stubEnv("REDIS_URL", "redis://localhost:6379");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe("runRedisCommand", () => {

--- a/apps/frontend/app/redis.test.ts
+++ b/apps/frontend/app/redis.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { closeRedisClient, runRedisCommand } from "./redis";
+
+const createClient = vi.hoisted(() => vi.fn());
+
+vi.mock("redis", () => ({
+  createClient,
+}));
+
+type MockRedisClient = {
+  isOpen: boolean;
+  isReady: boolean;
+  connect: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+  quit: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(async () => {
+  await closeRedisClient();
+  createClient.mockReset();
+  vi.stubEnv("REDIS_URL", "redis://localhost:6379");
+});
+
+describe("runRedisCommand", () => {
+  test("connects lazily and shares the same connect promise for concurrent commands", async () => {
+    const client = createMockRedisClient();
+    createClient.mockReturnValue(client);
+
+    const results = await Promise.all([
+      runRedisCommand(async (redis) => redis),
+      runRedisCommand(async (redis) => redis),
+    ]);
+
+    expect(createClient).toHaveBeenCalledTimes(1);
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        socket: expect.objectContaining({
+          connectTimeout: 5000,
+          reconnectStrategy: expect.any(Function),
+        }),
+        url: "redis://localhost:6379",
+      }),
+    );
+    expect(client.connect).toHaveBeenCalledTimes(1);
+    expect(results).toEqual([client, client]);
+  });
+
+  test("reconnects and retries once after ECONNRESET", async () => {
+    const firstClient = createMockRedisClient();
+    const secondClient = createMockRedisClient();
+    createClient
+      .mockReturnValueOnce(firstClient)
+      .mockReturnValueOnce(secondClient);
+    const command = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+      )
+      .mockResolvedValueOnce("ok");
+
+    await expect(runRedisCommand(command)).resolves.toBe("ok");
+
+    expect(command).toHaveBeenCalledTimes(2);
+    expect(command).toHaveBeenNthCalledWith(1, firstClient);
+    expect(command).toHaveBeenNthCalledWith(2, secondClient);
+    expect(firstClient.destroy).toHaveBeenCalledTimes(1);
+    expect(secondClient.destroy).not.toHaveBeenCalled();
+  });
+
+  test("does not retry non-transient command errors", async () => {
+    const client = createMockRedisClient();
+    createClient.mockReturnValue(client);
+    const error = new Error("WRONGTYPE Operation against a key");
+    const command = vi.fn().mockRejectedValue(error);
+
+    await expect(runRedisCommand(command)).rejects.toThrow(error);
+
+    expect(command).toHaveBeenCalledTimes(1);
+    expect(client.destroy).not.toHaveBeenCalled();
+  });
+
+  test("surfaces repeated transient failures after one retry", async () => {
+    const firstClient = createMockRedisClient();
+    const secondClient = createMockRedisClient();
+    createClient
+      .mockReturnValueOnce(firstClient)
+      .mockReturnValueOnce(secondClient);
+    const error = Object.assign(new Error("Socket closed unexpectedly"), {
+      code: "ECONNRESET",
+    });
+    const command = vi.fn().mockRejectedValue(error);
+
+    await expect(runRedisCommand(command)).rejects.toThrow(error);
+
+    expect(command).toHaveBeenCalledTimes(2);
+    expect(firstClient.destroy).toHaveBeenCalledTimes(1);
+    expect(secondClient.destroy).not.toHaveBeenCalled();
+  });
+});
+
+function createMockRedisClient(): MockRedisClient {
+  const client: MockRedisClient = {
+    isOpen: false,
+    isReady: false,
+    connect: vi.fn(),
+    destroy: vi.fn(),
+    quit: vi.fn(),
+    on: vi.fn(),
+  };
+
+  client.connect.mockImplementation(async () => {
+    client.isOpen = true;
+    client.isReady = true;
+    return client;
+  });
+
+  return client;
+}

--- a/apps/frontend/app/redis.ts
+++ b/apps/frontend/app/redis.ts
@@ -1,29 +1,199 @@
 import { createClient } from "redis";
 
-const redisUrl = process.env.REDIS_URL;
-if (!redisUrl) throw new Error("REDIS_URL is not defined");
+export type RedisClient = ReturnType<typeof createClient>;
 
-if (!globalThis.redis) {
-  globalThis.redis = createClient({ url: redisUrl });
-  globalThis.redis.connect();
+type RedisState = {
+  client?: RedisClient;
+  connectPromise?: Promise<RedisClient>;
+  signalHandlersRegistered?: boolean;
+};
+
+const REDIS_CONNECT_TIMEOUT_IN_MS = 5000;
+const REDIS_RECONNECT_DELAY_CAP_IN_MS = 3000;
+const TRANSIENT_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ENETUNREACH",
+  "ECONNABORTED",
+]);
+const TRANSIENT_ERROR_MESSAGES = [
+  "Socket closed unexpectedly",
+  "The client is closed",
+  "connection timeout",
+  "connect timeout",
+  "offline",
+];
+
+const redisState = getRedisState();
+
+export async function runRedisCommand<T>(
+  command: (client: RedisClient) => Promise<T>,
+) {
+  try {
+    return await command(await getRedisClient());
+  } catch (error) {
+    if (!isTransientRedisError(error)) throw error;
+
+    console.warn(
+      `Redis command failed with a transient error. Reconnecting and retrying once: ${formatRedisError(error)}`,
+    );
+    await resetRedisClient();
+
+    return await command(await getRedisClient());
+  }
 }
 
-export const redis = globalThis.redis as ReturnType<typeof createClient>;
+export function isTransientRedisError(error: unknown) {
+  const errorCode = getErrorCode(error);
+  if (errorCode && TRANSIENT_ERROR_CODES.has(errorCode)) return true;
 
-redis.on("error", (err) => console.error("Redis Client Error", err));
+  const message = getErrorMessage(error);
+  return TRANSIENT_ERROR_MESSAGES.some((transientMessage) =>
+    message.toLowerCase().includes(transientMessage.toLowerCase()),
+  );
+}
+
+export async function closeRedisClient() {
+  const client = redisState.client;
+  redisState.client = undefined;
+  redisState.connectPromise = undefined;
+
+  if (!client) return;
+
+  if (client.isOpen) {
+    await client.quit();
+  } else {
+    client.destroy();
+  }
+}
+
+async function getRedisClient() {
+  if (redisState.client?.isReady) {
+    return redisState.client;
+  }
+
+  if (redisState.connectPromise) {
+    return redisState.connectPromise;
+  }
+
+  if (redisState.client) {
+    await resetRedisClient();
+  }
+
+  redisState.client = createRedisClient();
+  redisState.connectPromise = redisState.client
+    .connect()
+    .then(() => {
+      if (!redisState.client) {
+        throw new Error("Redis client was reset while connecting");
+      }
+
+      return redisState.client;
+    })
+    .finally(() => {
+      redisState.connectPromise = undefined;
+    });
+
+  return redisState.connectPromise;
+}
+
+function createRedisClient() {
+  const redisUrl = process.env.REDIS_URL;
+  if (!redisUrl) throw new Error("REDIS_URL is not defined");
+
+  const client = createClient({
+    url: redisUrl,
+    socket: {
+      connectTimeout: REDIS_CONNECT_TIMEOUT_IN_MS,
+      reconnectStrategy: (retries) => {
+        const jitter = Math.floor(Math.random() * 100);
+        const delay = Math.min(
+          Math.pow(2, retries) * 50,
+          REDIS_RECONNECT_DELAY_CAP_IN_MS,
+        );
+
+        return delay + jitter;
+      },
+    },
+  });
+
+  client.on("error", (err) => console.error("Redis Client Error", err));
+  client.on("reconnecting", () => console.warn("Redis client reconnecting"));
+  client.on("ready", () => console.log("Redis client ready"));
+  client.on("end", () => console.log("Redis client connection closed"));
+
+  return client;
+}
+
+async function resetRedisClient() {
+  const client = redisState.client;
+  redisState.client = undefined;
+  redisState.connectPromise = undefined;
+
+  if (!client) return;
+
+  try {
+    client.destroy();
+  } catch (error) {
+    console.warn(
+      `Failed to destroy stale Redis client: ${formatRedisError(error)}`,
+    );
+  }
+}
+
+function registerRedisSignalHandlers() {
+  if (redisState.signalHandlersRegistered) return;
+
+  redisState.signalHandlersRegistered = true;
+
+  process.on("SIGINT", async () => {
+    console.log("SIGINT received. Closing Redis connection...");
+    try {
+      await closeRedisClient();
+    } finally {
+      process.exit(0);
+    }
+  });
+
+  process.on("SIGTERM", async () => {
+    console.log("SIGTERM received. Closing Redis connection...");
+    try {
+      await closeRedisClient();
+    } finally {
+      process.exit(0);
+    }
+  });
+}
+
+function getRedisState() {
+  globalThis.lapuertahostelsRedisState ??= {};
+  return globalThis.lapuertahostelsRedisState;
+}
+
+function getErrorCode(error: unknown) {
+  return typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string"
+    ? error.code
+    : null;
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function formatRedisError(error: unknown) {
+  const code = getErrorCode(error);
+  const message = getErrorMessage(error);
+
+  return code ? `${code}: ${message}` : message;
+}
 
 declare global {
-  var redis: ReturnType<typeof createClient> | undefined;
+  var lapuertahostelsRedisState: RedisState | undefined;
 }
 
-process.on("SIGINT", async () => {
-  console.log("SIGINT received. Closing Redis connection...");
-  await redis.quit();
-  process.exit(0);
-});
-
-process.on("SIGTERM", async () => {
-  console.log("SIGTERM received. Closing Redis connection...");
-  await redis.quit();
-  process.exit(0);
-});
+registerRedisSignalHandlers();


### PR DESCRIPTION
## Summary

- make the frontend Redis client lazy, reconnectable, and able to retry transient stale-socket failures once
- treat Redis cache read/write/delete failures as non-fatal during normal CMS page data loading
- keep authenticated cache purge strict so failed Redis flushes surface as errors
- add Vitest coverage for Redis reconnect behavior and CMS cache fallback behavior

## Context

Fly.io suspend/resume can restore the Node process with Redis TCP sockets that look open locally but have been closed by the remote side. The first request after resume can then fail with `read ECONNRESET`. This keeps Fly suspend enabled for cost savings while making Redis behave like a resilient cache dependency.

## Risks and Mitigations

- **Risk:** Redis outages could hide cache freshness problems during normal page loads. **Mitigation:** failures are logged and CMS data is loaded directly; explicit purge remains strict.
- **Risk:** reconnect logic could retry non-network application errors. **Mitigation:** retry is limited to known transient socket/client-state errors and only happens once.
- **Risk:** test env/global stubs could leak across Vitest files. **Mitigation:** tests now restore stubbed env vars and globals after each test.

## Validation

Local checks:

- `pnpm --filter @lapuertahostels/frontend check-format`
- `pnpm --filter @lapuertahostels/frontend lint`
- `pnpm --filter @lapuertahostels/frontend test`

GitHub Actions on PR #404:

- Frontend typecheck passed
- Frontend unit tests passed
- Frontend lint and format passed
- Frontend build and preview deploy passed
- CMS build, lint, and format passed
- End-to-end tests passed

## Known Limitations

Local `pnpm --filter @lapuertahostels/frontend typecheck` still fails in this worktree because generated Payload types are missing locally. The PR CI generates/populates those types first, and the CI typecheck is passing.
