### PR TITLE
ci: pin webplatform workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: "Build"
-    uses: fxmkdev/webplatform/.github/workflows/export.build.yml@main
+    uses: fxmkdev/webplatform/.github/workflows/export.build.yml@v0.9.1
     permissions:
       contents: write
     secrets: inherit

--- a/.github/workflows/clean-preview.yml
+++ b/.github/workflows/clean-preview.yml
@@ -7,5 +7,5 @@ on:
 jobs:
   clean-preview:
     name: Clean Preview
-    uses: fxmkdev/webplatform/.github/workflows/export.clean-preview.yml@main
+    uses: fxmkdev/webplatform/.github/workflows/export.clean-preview.yml@v0.9.1
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   deploy:
     name: "Deploy"
-    uses: fxmkdev/webplatform/.github/workflows/export.deploy.yml@main
+    uses: fxmkdev/webplatform/.github/workflows/export.deploy.yml@v0.9.1
     with:
       environment: ${{ inputs.environment }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pin exported reusable workflows from `fxmkdev/webplatform` to `v0.9.1` instead of `main`.
- Apply the pin consistently to build, deploy, and clean-preview workflows.

## Why

Using `main` made this repository silently adopt workflow changes from `webplatform`. Pinning the workflows lets upgrades happen intentionally through reviewable PRs.

## Validation

- `rg -n "fxmkdev/webplatform/.github/workflows/.*@main" .github/workflows` found no remaining matches.
- `git diff --check HEAD~1..HEAD` passed.