### PR TITLE
feat(cms): migrate media categories to folders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,9 @@ It includes:
 ## Repository-wide Guidelines
 
 - Use `pnpm` as package manager.
+- Before starting coding work, fetch and start from the latest `origin/main`.
+  For existing pull request branches, rebase onto the latest `origin/main`
+  before pushing updates.
 - Keep changes focused and minimal; avoid unrelated refactors.
 - Keep docs in sync when introducing new behavior, patterns, or conventions.
 - The runtime target is Node 24. Keep `@types/node` aligned with the current
@@ -87,6 +90,8 @@ pnpm --filter @lapuertahostels/e2e e2e                   # Run Playwright e2e UI
   shared workspace package with
   `pnpm --filter @lapuertahostels/payload-types pull-payload-types` when schema
   changes need to be consumed outside the CMS.
+- `@fxmk/cms-plugin` and `@fxmk/common` come from the same source repository.
+  Always update them together to the same version wherever they are declared.
 - Keep CMS configuration and custom blocks close to `apps/cms/src/`, and keep
   frontend rendering concerns in `apps/frontend/app/`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,12 @@ Recommended types:
 Commits inside a pull request can stay descriptive for review flow and do not
 need to be strictly Conventional Commit formatted.
 
+## Branch Freshness
+
+- Coding agents should fetch and start new work from the latest `origin/main`.
+- For existing pull request branches, rebase onto the latest `origin/main`
+  before pushing updates.
+
 ## Pull Request Description Workflow
 
 - Prefer `gh pr create --body-file <path>` over `--body` to avoid shell
@@ -52,6 +58,11 @@ need to be strictly Conventional Commit formatted.
 
 - Keep `@types/node` on the Node 24 line until the next runtime migration is
   scheduled.
+
+## Shared Package Version Policy
+
+- `@fxmk/cms-plugin` and `@fxmk/common` come from the same source repository.
+  Always update them together to the same version wherever they are declared.
 
 ## Review Comment Workflow
 

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -17,7 +17,7 @@
     "check-format": "prettier --check ."
   },
   "dependencies": {
-    "@fxmk/cms-plugin": "0.9.2",
+    "@fxmk/cms-plugin": "0.9.3",
     "@payloadcms/db-mongodb": "^3.84.1",
     "@payloadcms/email-resend": "^3.84.1",
     "@payloadcms/next": "^3.84.1",

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -17,7 +17,7 @@
     "check-format": "prettier --check ."
   },
   "dependencies": {
-    "@fxmk/cms-plugin": "0.9.0",
+    "@fxmk/cms-plugin": "0.9.2",
     "@payloadcms/db-mongodb": "^3.84.1",
     "@payloadcms/email-resend": "^3.84.1",
     "@payloadcms/next": "^3.84.1",

--- a/apps/cms/src/migrations/20260608_000000_migrate_media_categories_to_folders.ts
+++ b/apps/cms/src/migrations/20260608_000000_migrate_media_categories_to_folders.ts
@@ -1,0 +1,15 @@
+import { migrateMediaCategoriesToFolders } from "@fxmk/cms-plugin";
+import { MigrateDownArgs, MigrateUpArgs } from "@payloadcms/db-mongodb";
+
+export async function up({ payload, req }: MigrateUpArgs): Promise<void> {
+  const result = await migrateMediaCategoriesToFolders({
+    payload,
+    req,
+  });
+
+  console.log("Migrated media categories to folders", result);
+}
+
+export async function down(_: MigrateDownArgs): Promise<void> {
+  // Migration code
+}

--- a/apps/cms/src/migrations/index.ts
+++ b/apps/cms/src/migrations/index.ts
@@ -8,6 +8,7 @@ import * as migration_20260529_000000_optional_room_cta from "./20260529_000000_
 import * as migration_20260529_224952_accommodation_selector_card_links from "./20260529_224952_accommodation_selector_card_links";
 import * as migration_20260606_194625_migrate_brand_root_paths from "./20260606_194625_migrate_brand_root_paths";
 import * as migration_20260606_210000_migrate_brand_theme_colors from "./20260606_210000_migrate_brand_theme_colors";
+import * as migration_20260608_000000_migrate_media_categories_to_folders from "./20260608_000000_migrate_media_categories_to_folders";
 
 export const migrations = [
   {
@@ -59,5 +60,10 @@ export const migrations = [
     up: migration_20260606_210000_migrate_brand_theme_colors.up,
     down: migration_20260606_210000_migrate_brand_theme_colors.down,
     name: "20260606_210000_migrate_brand_theme_colors",
+  },
+  {
+    up: migration_20260608_000000_migrate_media_categories_to_folders.up,
+    down: migration_20260608_000000_migrate_media_categories_to_folders.down,
+    name: "20260608_000000_migrate_media_categories_to_folders",
   },
 ];

--- a/apps/cms/src/payload.config.ts
+++ b/apps/cms/src/payload.config.ts
@@ -53,6 +53,10 @@ export default buildConfig({
     cmsPlugin({
       additionalContentBlocks: [RoomListBlock, AccommodationSelectorBlock],
       additionalUiLabelFields,
+      media: {
+        organization: "folders",
+        retainLegacyCategories: true,
+      },
       mediaS3Storage: {
         bucket: process.env.MEDIA_S3_BUCKET!,
         region: process.env.MEDIA_S3_REGION!,

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -15,7 +15,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@fxmk/common": "0.9.0",
+    "@fxmk/common": "0.9.2",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@lapuertahostels/payload-types": "workspace:../../libs/payload-types",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -15,7 +15,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@fxmk/common": "0.9.2",
+    "@fxmk/common": "0.9.3",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@lapuertahostels/payload-types": "workspace:../../libs/payload-types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
   apps/cms:
     dependencies:
       '@fxmk/cms-plugin':
-        specifier: 0.9.2
-        version: 0.9.2(128199f210e2ca31efa9dd2040f35b6b)
+        specifier: 0.9.3
+        version: 0.9.3(128199f210e2ca31efa9dd2040f35b6b)
       '@payloadcms/db-mongodb':
         specifier: ^3.84.1
         version: 3.84.1(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))
@@ -106,8 +106,8 @@ importers:
   apps/frontend:
     dependencies:
       '@fxmk/common':
-        specifier: 0.9.2
-        version: 0.9.2
+        specifier: 0.9.3
+        version: 0.9.3
       '@headlessui/react':
         specifier: ^2.2.10
         version: 2.2.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -278,8 +278,8 @@ importers:
   tests/e2e:
     devDependencies:
       '@fxmk/common':
-        specifier: 0.9.2
-        version: 0.9.2
+        specifier: 0.9.3
+        version: 0.9.3
       '@lapuertahostels/payload-types':
         specifier: workspace:../../libs/payload-types
         version: link:../../libs/payload-types
@@ -1228,8 +1228,8 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@fxmk/cms-plugin@0.9.2':
-    resolution: {integrity: sha512-GzSNh5Uj2MjKQcVzWRFipemNSji2eArUe1g+Ld5YZdP4twcuc05u7dXa7vnj0uUmFZZH0S0zXkvfZLqt7sGn5w==}
+  '@fxmk/cms-plugin@0.9.3':
+    resolution: {integrity: sha512-h1vUudeSZEtousDNg3baDHBFi/vpQ6iM2qe9HQ7Zd2/DJeMQQk3lTQu3T1JoDiuVLFLX9LZhBZQdgA+tSOhuLA==}
     engines: {node: '>=24.0.0', pnpm: ^9 || ^10 || ^11}
     peerDependencies:
       '@payloadcms/db-mongodb': ^3.84.1
@@ -1241,8 +1241,8 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@fxmk/common@0.9.2':
-    resolution: {integrity: sha512-IjoSEpSfVDrBdli6QXFyr6B+fBADicXInqT3hLlYj8LCGo5lgUiRvysTHSIBn1v/l9ArFyVJlbgNqQ63Z9cJ1A==}
+  '@fxmk/common@0.9.3':
+    resolution: {integrity: sha512-17hBv36YluvYizTYWYJhUVrNkJu5tti/KCwtTTsbUhxoJ1XypXv39LWrFUc/j/6EQULiyIFil1BdNR1A/+iAeQ==}
 
   '@fxmk/releaser@0.5.5':
     resolution: {integrity: sha512-QJNeR1vVYwzvj2souXsZ1F1jxr/FQ4wHiMzRK1dIh1WoKoW6cepRzL7sBdQJtr2SphJIf1M/DQBuhR8b1xLxuw==}
@@ -8096,7 +8096,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fxmk/cms-plugin@0.9.2(128199f210e2ca31efa9dd2040f35b6b)':
+  '@fxmk/cms-plugin@0.9.3(128199f210e2ca31efa9dd2040f35b6b)':
     dependencies:
       '@payloadcms/db-mongodb': 3.84.1(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))
       '@payloadcms/richtext-lexical': 3.84.1(@faceless-ui/modal@3.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@payloadcms/next@3.84.1(@types/react@19.2.15)(graphql@16.10.0)(monaco-editor@0.52.2)(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4))(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@types/react@19.2.15)(monaco-editor@0.52.2)(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4))(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)(yjs@13.6.23)
@@ -8118,7 +8118,7 @@ snapshots:
       - debug
       - ws
 
-  '@fxmk/common@0.9.2': {}
+  '@fxmk/common@0.9.3': {}
 
   '@fxmk/releaser@0.5.5':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
   apps/cms:
     dependencies:
       '@fxmk/cms-plugin':
-        specifier: 0.9.0
-        version: 0.9.0(128199f210e2ca31efa9dd2040f35b6b)
+        specifier: 0.9.2
+        version: 0.9.2(128199f210e2ca31efa9dd2040f35b6b)
       '@payloadcms/db-mongodb':
         specifier: ^3.84.1
         version: 3.84.1(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))
@@ -106,8 +106,8 @@ importers:
   apps/frontend:
     dependencies:
       '@fxmk/common':
-        specifier: 0.9.0
-        version: 0.9.0
+        specifier: 0.9.2
+        version: 0.9.2
       '@headlessui/react':
         specifier: ^2.2.10
         version: 2.2.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -278,8 +278,8 @@ importers:
   tests/e2e:
     devDependencies:
       '@fxmk/common':
-        specifier: 0.9.0
-        version: 0.9.0
+        specifier: 0.9.2
+        version: 0.9.2
       '@lapuertahostels/payload-types':
         specifier: workspace:../../libs/payload-types
         version: link:../../libs/payload-types
@@ -1228,8 +1228,8 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@fxmk/cms-plugin@0.9.0':
-    resolution: {integrity: sha512-xlm91uZImEr0uRhpFIU+Wo31q0QtZ61diDHzvhiYs+Wt+EI7pItsCzbs6CSayyfEeq8DjHZ4tfwo6z+8gaJJHw==}
+  '@fxmk/cms-plugin@0.9.2':
+    resolution: {integrity: sha512-GzSNh5Uj2MjKQcVzWRFipemNSji2eArUe1g+Ld5YZdP4twcuc05u7dXa7vnj0uUmFZZH0S0zXkvfZLqt7sGn5w==}
     engines: {node: '>=24.0.0', pnpm: ^9 || ^10 || ^11}
     peerDependencies:
       '@payloadcms/db-mongodb': ^3.84.1
@@ -1241,8 +1241,8 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@fxmk/common@0.9.0':
-    resolution: {integrity: sha512-ffbdbzAcGFX7N/b9oBqj0jmtba5mQYkgywOW/I2oy+x/3jNBXiBrUE34UJQ6X8dBIe2GPMF4M+3Ftpbu+tdJSg==}
+  '@fxmk/common@0.9.2':
+    resolution: {integrity: sha512-IjoSEpSfVDrBdli6QXFyr6B+fBADicXInqT3hLlYj8LCGo5lgUiRvysTHSIBn1v/l9ArFyVJlbgNqQ63Z9cJ1A==}
 
   '@fxmk/releaser@0.5.5':
     resolution: {integrity: sha512-QJNeR1vVYwzvj2souXsZ1F1jxr/FQ4wHiMzRK1dIh1WoKoW6cepRzL7sBdQJtr2SphJIf1M/DQBuhR8b1xLxuw==}
@@ -8096,7 +8096,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fxmk/cms-plugin@0.9.0(128199f210e2ca31efa9dd2040f35b6b)':
+  '@fxmk/cms-plugin@0.9.2(128199f210e2ca31efa9dd2040f35b6b)':
     dependencies:
       '@payloadcms/db-mongodb': 3.84.1(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))
       '@payloadcms/richtext-lexical': 3.84.1(@faceless-ui/modal@3.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@payloadcms/next@3.84.1(@types/react@19.2.15)(graphql@16.10.0)(monaco-editor@0.52.2)(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4))(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(@types/react@19.2.15)(monaco-editor@0.52.2)(next@16.2.6(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4))(payload@3.84.1(graphql@16.10.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)(yjs@13.6.23)
@@ -8118,7 +8118,7 @@ snapshots:
       - debug
       - ws
 
-  '@fxmk/common@0.9.0': {}
+  '@fxmk/common@0.9.2': {}
 
   '@fxmk/releaser@0.5.5':
     dependencies:

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@fxmk/common": "0.9.2",
+    "@fxmk/common": "0.9.3",
     "@lapuertahostels/payload-types": "workspace:../../libs/payload-types",
     "@paralleldrive/cuid2": "^3.3.0",
     "@playwright/test": "^1.60.0",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@fxmk/common": "0.9.0",
+    "@fxmk/common": "0.9.2",
     "@lapuertahostels/payload-types": "workspace:../../libs/payload-types",
     "@paralleldrive/cuid2": "^3.3.0",
     "@playwright/test": "^1.60.0",


### PR DESCRIPTION
## Summary

- Enable Payload media folders through `@fxmk/cms-plugin` while retaining legacy media categories for the migration rollout.
- Add a Payload migration that uses `migrateMediaCategoriesToFolders` to create/reuse top-level folders from existing media categories.
- Upgrade `@fxmk/cms-plugin` and `@fxmk/common` together to `0.9.2` and document that version-sync rule.
- Update frontend CMS data builders for the regenerated `Brand.themeColor` type.

## Validation

- `pnpm --filter @lapuertahostels/cms build`
- `pnpm --filter @lapuertahostels/cms lint`
- `pnpm --filter @lapuertahostels/cms check-format`
- `pnpm --filter @lapuertahostels/frontend typecheck`
- `pnpm --filter @lapuertahostels/frontend lint`
- `pnpm --filter @lapuertahostels/frontend check-format`
- `git diff --check`

## Rollout Notes

This is phase 1 of the media folders rollout. `retainLegacyCategories: true` intentionally keeps the old category collection and hidden media category field available while the migration runs and folder assignments are verified. A follow-up change should remove `retainLegacyCategories` after verification.