### PR TITLE
fix(deps): pin shell-quote to 1.8.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   postcss@8.4.31: 8.5.14
   qs: 6.15.2
   react-d3-tree>uuid: 11.1.1
+  shell-quote: 1.8.4
   tar: 7.5.15
   uuid@11.1.0: 11.1.1
   ws: 8.20.1
@@ -6282,8 +6283,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -12250,7 +12251,7 @@ snapshots:
   launch-editor@2.13.2:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   levn@0.4.1:
     dependencies:
@@ -13674,7 +13675,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ overrides:
   "postcss@8.4.31": 8.5.14
   qs: 6.15.2
   "react-d3-tree>uuid": 11.1.1
+  shell-quote: 1.8.4
   tar: 7.5.15
   "uuid@11.1.0": 11.1.1
   ws: 8.20.1


### PR DESCRIPTION
## Summary
- add a workspace override for `shell-quote` to force the patched `1.8.4` release
- refresh `pnpm-lock.yaml` so the `launch-editor` transitive dependency resolves to `shell-quote@1.8.4`
- address Dependabot alert [#228](https://github.com/fxmkdev/lapuertahostels/security/dependabot/228) (`GHSA-w7jw-789q-3m8p` / `CVE-2026-9277`)

## Verification
- `pnpm --filter @lapuertahostels/frontend lint`
- `pnpm --filter @lapuertahostels/frontend typecheck` *(fails due to pre-existing shared payload-types/type export issues, unrelated to this dependency bump)*